### PR TITLE
Add Laravel 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
+        php-versions: ['8.2', '8.3', '8.4']
 
     name: PHP ${{ matrix.php-versions }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Please note this changelog affects this package and not the 
 HiHaHo API.
 
+## [6.0.0]
+
+### Added
+
+- Add support for Laravel 12.
+- Add support for PHP 8.4.
+
+### Removed
+
+- Drop support for Laravel version older than 11.
+- Drop support for PHP versions older than 8.2.
+
 ## [5.0.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the endpoint. It's also possible to extend the client.
 
 ## Requirements
 
-This package requires at least PHP 7.4.
+This package requires at least PHP 8.2.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": ">=8.2",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0",
-        "illuminate/http": "^8.74|^9.0|^10.0|^11.0",
-        "illuminate/support": "^8.22|^9.0|^10.0|^11.0"
+        "illuminate/http": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
         "phpstan/phpstan": "^1.2",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
     <report>
       <html outputDirectory="./build/report/"/>
     </report>
@@ -13,4 +10,9 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/pint.json
+++ b/pint.json
@@ -2,6 +2,7 @@
     "preset": "laravel",
     "rules": {
         "array_indentation": false,
-        "phpdoc_align": false
+        "phpdoc_align": false,
+        "new_with_parentheses": false
     }
 }

--- a/src/HiHaHo.php
+++ b/src/HiHaHo.php
@@ -15,7 +15,7 @@ class HiHaHo extends Factory
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '5.0.0';
+    private const VERSION = '6.0.0';
 
     private const USER_AGENT = 'vdhicts-hihaho-api-client/'.self::VERSION;
 

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -8,7 +8,7 @@ use Vdhicts\HiHaHo\Configuration;
 
 class ConfigurationTest extends TestCase
 {
-    public function testInitialisation()
+    public function test_initialisation()
     {
         $clientId = 'ClientId';
         $clientSecret = 'ClientSecret';
@@ -25,7 +25,7 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($configuration->hasRefreshToken());
     }
 
-    public function testProvidingTokens()
+    public function test_providing_tokens()
     {
         $configuration = new Configuration(
             'ClientId',
@@ -44,7 +44,7 @@ class ConfigurationTest extends TestCase
         $this->assertSame($refreshToken, $configuration->getRefreshToken());
     }
 
-    public function testProvidingUrl()
+    public function test_providing_url()
     {
         $configuration = new Configuration(
             'ClientId',

--- a/tests/Unit/HiHaHoTest.php
+++ b/tests/Unit/HiHaHoTest.php
@@ -10,7 +10,7 @@ use Vdhicts\HiHaHo\HiHaHo;
 
 class HiHaHoTest extends TestCase
 {
-    public function testRequest()
+    public function test_request()
     {
         $videoId = rand(1000, 9999);
         $accessToken = Str::random();


### PR DESCRIPTION
# Changes

### Added

- Add support for Laravel 12.
- Add support for PHP 8.4.

### Removed

- Drop support for Laravel version older than 11.
- Drop support for PHP versions older than 8.2.

# Checks

- [x] The changelog is updated (when applicable)
- [x] The version is updated in `HiHaHo.php` (when applicable)
